### PR TITLE
Include README.md in dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,9 @@
 # Generated files that 'make clean' should erase
 CLEANFILES =
 DISTCLEANFILES =
-EXTRA_DIST =
+
+# Extra files to distribute in the tarball
+EXTRA_DIST = README.md
 
 # # # INSTALL RULES # # #
 


### PR DESCRIPTION
We ship the readme as documentation for debian package so in needs
to be included in dist
[endlessm/eos-sdk#1141]
