### PR TITLE
Xapian bridge activates with systemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ AC_CACHE_SAVE
 EOS_CHECK_GJS_GIR([GLib], [2.0])
 EOS_CHECK_GJS_GIR([GObject], [2.0])
 EOS_CHECK_GJS_GIR([Soup], [2.4])
+EOS_CHECK_GJS_GIR_API([Soup], [Server.prototype.listen_fd])
 EOS_CHECK_GJS_GIR([Xapian], [1.0])
 
 AC_CACHE_SAVE

--- a/src/xapianBridge.js
+++ b/src/xapianBridge.js
@@ -1,4 +1,5 @@
 const Soup = imports.gi.Soup;
+const GLib = imports.gi.GLib;
 
 const DatabaseCache = imports.databaseCache.DatabaseCache;
 const DatabaseManager = imports.databaseManager.DatabaseManager;
@@ -13,9 +14,22 @@ const META_DATABASE_NAME = '_all';
 const META_DATABASE_METHODS = 'GET';
 
 function main () {
-    let server = new RoutedServer({
-        port: DEFAULT_PORT
-    });
+    let server = new RoutedServer();
+    let fd = NaN;
+    // If this service is launched by systemd, LISTEN_PID and LISTEN_FDS will
+    // be set by systemd and we should set up the server to use the fd instead
+    // of a port
+    if (GLib.getenv("LISTEN_PID") !== null) {
+        fd_string = GLib.getenv("LISTEN_FDS");
+        if (fd_string !== null) {
+            fd = parseInt(fd_string, 10);
+        }
+    }
+    if (!isNaN(fd)) {
+        server.listen_fd(fd, 0);
+    } else {
+        server.listen_local(DEFAULT_PORT, 0);
+    }
 
     let cache = new DatabaseCache();
     let manager = new DatabaseManager();


### PR DESCRIPTION
Modeled after node-systemd, load from a file descriptor if the process
was launched with systemd, otherwise load directly on port 3004
[endlessm/eos-sdk#1141]
