### PR TITLE
Meta databases clone children before adding them

### DIFF
--- a/src/databaseManager.js
+++ b/src/databaseManager.js
@@ -111,7 +111,11 @@ const DatabaseManager = Lang.Class({
 
         Object.keys(this._databases).forEach(function (index_name) {
             let child_db = this._databases[index_name];
-            db.add_database(child_db);
+            let child_clone = new Xapian.Database({
+                path: child_db.path
+            });
+            child_clone.init(null);
+            db.add_database(child_clone);
         }.bind(this));
 
         return db;


### PR DESCRIPTION
Apparently, when a Xapian::Database is closed (as happens when its gobject
wrapper is finalized), any child databases added with Database::add_database
are also closed. This is an undocumented "feature" of Xapian and not a fault
of our bindings.

Until upstream Xapian gives some insight into a better way of
accomplishing our desired functionality (a set of "tracking" databases which can
be set up/torn down without affecting their children), we'll clone each child
database before adding it to the parent. That way when the parent inevitably
closes, the databases accessed via their normal index names won't be affected

[endlessm/eos-sdk#1375]
