### PR TITLE
Removed db cloning since Database::close got nixed

### DIFF
--- a/src/databaseManager.js
+++ b/src/databaseManager.js
@@ -117,11 +117,7 @@ const DatabaseManager = Lang.Class({
             return selectAll || this._database_langs[index_name] === lang; 
         }.bind(this)).forEach(function (index_name) {
             let child_db = this._databases[index_name];
-            let child_clone = new Xapian.Database({
-                path: child_db.path
-            });
-            child_clone.init(null);
-            db.add_database(child_clone);
+            db.add_database(child_db);
         }.bind(this));
 
         return db;


### PR DESCRIPTION
Our GObject bindings no longer call Database::close on finalize, so we don't
need to make clones of our databases when using Database::add_database anymore

[endlessm/eos-sdk#1408]
