### PR TITLE
Check if offset and limit parameters are numbers

### DIFF
--- a/src/xapianBridge.js
+++ b/src/xapianBridge.js
@@ -146,9 +146,9 @@ function main () {
         let index_name = params.index_name;
         let q = query.q;
         let collapse_key = query.collapse;
-        let limit = query.limit;
-        let offset = query.offset;
-        if (typeof limit === 'undefined' || typeof offset === 'undefined') {
+        let limit = parseInt(query.limit);
+        let offset = parseInt(query.offset);
+        if (isNaN(limit) || isNaN(offset)) {
             return res(msg, Soup.Status.BAD_REQUEST);
         }
 


### PR DESCRIPTION
Previously, we were not converting the limit and offset
parameters to integer types, which meant that a) there
was no verification that they were valid numbers and b)
they were sent back as type string to the client, which
was wrong. This ensures that they are converted to valid
numbers.
