### PR TITLE
Require libsoup 2.48

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,9 +70,10 @@ AC_CACHE_SAVE
 # Required libraries
 # ------------------
 m4_define(glib_minver, 2.40.0)
+m4_define(soup_minver, 2.48.0)
 PKG_CHECK_MODULES(XAPIAN_BRIDGE, [gio-2.0 >= glib_minver
                                   json-glib-1.0
-                                  libsoup-2.4
+                                  libsoup-2.4 >= soup_minver
                                   xapian-glib-1.0])
 
 # systemd units


### PR DESCRIPTION
If we don't check for this, then compilation will fail, which is harder
to diagnose.

[endlessm/eos-sdk#3075]