### PR TITLE
Makefile: Move to AM_DISTCHECK_CONFIGURE_FLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ generate-dbs: generate-test-db
 MAINTAINERCLEANFILES = test/testdb
 
 # Specify a non-system dir for systemd units at distcheck
-DISTCHECK_CONFIGURE_FLAGS = \
+AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_INIT([Xapian Bridge], [_XAPIAN_BRIDGE_API_VERSION_MACRO],
     [], [xapian-bridge], [http://endlessm.com])
 # Initialize Automake: enable all warnings and do not insist on GNU standards
 # no-portability suppresses warnings about syntax specific to GNU make
-AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign dist-xz no-dist-gzip 1.9 tar-ustar parallel-tests])
+AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign dist-xz no-dist-gzip 1.11.2 tar-ustar parallel-tests])
 # Avoid spewing garbage over the terminal ('make V=1' to see the garbage)
 AM_SILENT_RULES([yes])
 # Keep Autotools macros local to this source tree


### PR DESCRIPTION
Since automake 1.11.2 we should be using this instead of
DISTCHECK_CONFIGURE_FLAGS as the latter is a user variable.

[endlessm/eos-sdk#3303]