### PR TITLE
Support loading multi-file databases from a manifest file

### DIFF
--- a/src/xb-database-manager.h
+++ b/src/xb-database-manager.h
@@ -45,7 +45,7 @@ struct _XbDatabaseManager
 
 typedef struct {
     const char *path;
-    off_t offset;
+    const char *manifest_path;
 } XbDatabase;
 
 GType xb_database_manager_get_type (void) G_GNUC_CONST;

--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -92,17 +92,13 @@ fill_xbdb_from_query (SoupMessage *message,
                       XbDatabase  *db)
 {
   db->path = g_hash_table_lookup (query, "path");
-  if (db->path == NULL)
+  db->manifest_path = g_hash_table_lookup (query, "manifest_path");
+
+  if (db->path == NULL && db->manifest_path == NULL)
     {
       server_send_response (message, SOUP_STATUS_BAD_REQUEST, NULL, NULL);
       return FALSE;
     }
-
-  const char *offset = g_hash_table_lookup (query, "db_offset");
-  if (offset)
-    db->offset = g_ascii_strtoull (offset, NULL, 10);
-  else
-    db->offset = 0;
 
   return TRUE;
 }


### PR DESCRIPTION
Remove the old db_offset feature, and replace it with the ability to
create a multi-file database from a manifest file.

[endlessm/eos-sdk#4051]
