### PR TITLE
main: simplify flatpak path rewrite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,8 +71,7 @@ AC_CACHE_SAVE
 # ------------------
 m4_define(glib_minver, 2.40.0)
 m4_define(soup_minver, 2.48.0)
-PKG_CHECK_MODULES(XAPIAN_BRIDGE, [flatpak,
-                                  gio-2.0 >= glib_minver
+PKG_CHECK_MODULES(XAPIAN_BRIDGE, [gio-2.0 >= glib_minver
                                   json-glib-1.0
                                   libsoup-2.4 >= soup_minver
                                   xapian-glib-1.0])

--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -89,8 +89,9 @@ server_send_response (SoupMessage *message,
 }
 
 static char *
-resolve_flatpak_path (const char *path,
-                      const char *app_id)
+get_real_path (const char *path,
+               const char *app_id,
+               gboolean for_subscriptions)
 {
   g_autofree char *real_path = g_file_read_link (path, NULL);
   if (!real_path)
@@ -150,9 +151,9 @@ fill_xbdb_from_query (SoupMessage *message,
       if (app_id != NULL)
         {
           if (path != NULL)
-            db->path = resolve_flatpak_path (path, app_id);
+            db->path = get_real_path (path, app_id, FALSE);
           if (manifest_path != NULL)
-            db->manifest_path = resolve_flatpak_path (manifest_path, app_id);
+            db->manifest_path = get_real_path (manifest_path, app_id, TRUE);
         }
     }
 


### PR DESCRIPTION
We now receive the full path to the app deploy in the query, so we don't
have to ask flatpak where the application is.
This also makes the bridge work in the case when it's autostarted by
systemd and the flatpak app lives in the user's home.

https://phabricator.endlessm.com/T11523