### PR TITLE
Turn the offset into a guint64

### DIFF
--- a/src/xb-database-manager.c
+++ b/src/xb-database-manager.c
@@ -380,7 +380,7 @@ create_database_from_manifest (const char  *manifest_path,
     {
       JsonObject *json_db = json_node_get_object (l->data);
 
-      int db_offset = json_object_get_int_member (json_db, "offset");
+      guint64 db_offset = json_object_get_int_member (json_db, "offset");
 
       const char *relpath = json_object_get_string_member (json_db, "path");
       g_autofree char *db_path = g_build_filename (manifest_dir_path, relpath, NULL);


### PR DESCRIPTION
There has been an ABI change in xapian-glib, in order to cope with very
large offsets.

https://phabricator.endlessm.com/T13324