### PR TITLE
build: Enable large file support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,10 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 AC_CACHE_SAVE
 
+# System features
+# ---------------
+AC_SYS_LARGEFILE
+
 # Required build tools
 # --------------------
 # Make sure we can create directory hierarchies


### PR DESCRIPTION
This is necessary for accessing Xapian databases inside shards of larger
than 2 GB on 32-bit systems.

https://phabricator.endlessm.com/T13324