### PR TITLE
Add way to test for supported features

### DIFF
--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -25,7 +25,6 @@
 #include <json-glib/json-glib.h>
 #include <libsoup/soup.h>
 #include <stdlib.h>
-#include <string.h>
 
 #define DEFAULT_PORT 3004
 #define META_DB_ALL "_all"
@@ -212,14 +211,10 @@ server_get_test_callback (GHashTable *params,
       return;
     }
 
-  if (strcmp (feature, "query-param-defaultOp") == 0)
-    {
-      server_send_response (message, SOUP_STATUS_OK, NULL, NULL);
-    }
+  if (g_strcmp0 (feature, "query-param-defaultOp") == 0)
+    server_send_response (message, SOUP_STATUS_OK, NULL, NULL);
   else
-    {
-      server_send_response (message, SOUP_STATUS_NOT_FOUND, NULL, NULL);
-    }
+    server_send_response (message, SOUP_STATUS_NOT_FOUND, NULL, NULL);
 }
 
 static gboolean

--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -202,9 +202,11 @@ server_get_test_callback (GHashTable *params,
                           gpointer user_data)
 {
   XapianBridge *xb = user_data;
-  const char *feature;
+  const char *feature = NULL;
 
-  feature = g_hash_table_lookup (query, "feature");
+  if (query)
+    feature = g_hash_table_lookup (query, "feature");
+
   if (feature == NULL)
     {
       server_send_response (message, SOUP_STATUS_BAD_REQUEST, NULL, NULL);

--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -25,6 +25,7 @@
 #include <json-glib/json-glib.h>
 #include <libsoup/soup.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define DEFAULT_PORT 3004
 #define META_DB_ALL "_all"
@@ -185,6 +186,42 @@ server_get_fix_callback (GHashTable *params,
     }
 }
 
+/* GET /test - test for existence of a particular feature
+ * Returns:
+ *     200 - Feature supported by this instance of xapian-bridge
+ *     400 - The required "feature" parameter wasn't specified
+ *     404 - Feature not supported by this instance of xapian-bridge
+ *
+ * Note: xapian-bridge versions predating the addition of /test return 500
+ * (default response to an unknown URL) so you typically want to handle 500
+ * in the same way as 404.
+ */
+static void
+server_get_test_callback (GHashTable *params,
+                          GHashTable *query,
+                          SoupMessage *message,
+                          gpointer user_data)
+{
+  XapianBridge *xb = user_data;
+  const char *feature;
+
+  feature = g_hash_table_lookup (query, "feature");
+  if (feature == NULL)
+    {
+      server_send_response (message, SOUP_STATUS_BAD_REQUEST, NULL, NULL);
+      return;
+    }
+
+  if (strcmp (feature, "query-param-defaultOp") == 0)
+    {
+      server_send_response (message, SOUP_STATUS_OK, NULL, NULL);
+    }
+  else
+    {
+      server_send_response (message, SOUP_STATUS_NOT_FOUND, NULL, NULL);
+    }
+}
+
 static gboolean
 sigterm_handler (gpointer user_data)
 {
@@ -271,6 +308,8 @@ xapian_bridge_new (GError **error_out)
                         server_get_query_callback, xb);
   xb_routed_server_get (server, "/fix",
                         server_get_fix_callback, xb);
+  xb_routed_server_get (server, "/test",
+                        server_get_test_callback, xb);
 
   return xb;
 }

--- a/test/test-daemon.c
+++ b/test/test-daemon.c
@@ -111,7 +111,7 @@ test_feature_testing_works (DaemonFixture *fixture,
   SoupMessage *message;
   gchar *req_uri;
 
-  // Test for a known feature.
+  /* Test for a known feature. */
   req_uri = g_strdup_printf ("http://localhost:%s/test?feature=query-param-defaultOp",
                              fixture->port);
 
@@ -136,8 +136,9 @@ test_feature_testing_works (DaemonFixture *fixture,
   g_object_unref (req);
   g_object_unref (session);
   g_object_unref (message);
+  g_object_unref (stream);
 
-  // Test for a unknown feature.
+  /* Test for a unknown feature. */
   req_uri = g_strdup_printf ("http://localhost:%s/test?feature=no-such-feature",
                              fixture->port);
 
@@ -162,8 +163,9 @@ test_feature_testing_works (DaemonFixture *fixture,
   g_object_unref (req);
   g_object_unref (session);
   g_object_unref (message);
+  g_object_unref (stream);
 
-  // Fail to specify a feature to test for.
+  /* Fail to specify a feature to test for. */
   req_uri = g_strdup_printf ("http://localhost:%s/test",
                              fixture->port);
 
@@ -188,6 +190,7 @@ test_feature_testing_works (DaemonFixture *fixture,
   g_object_unref (req);
   g_object_unref (session);
   g_object_unref (message);
+  g_object_unref (stream);
 }
 
 static void

--- a/test/test-daemon.c
+++ b/test/test-daemon.c
@@ -236,6 +236,7 @@ test_get_query_returns_json (DaemonFixture *fixture,
   g_object_unref (req);
   g_object_unref (session);
   g_object_unref (message);
+  g_object_unref (stream);
 }
 
 static void

--- a/test/test-daemon.c
+++ b/test/test-daemon.c
@@ -100,6 +100,97 @@ flush_stream_to_string (GInputStream *stream)
 }
 
 static void
+test_feature_testing_works (DaemonFixture *fixture,
+                            gconstpointer user_data)
+{
+  SoupSession *session;
+  SoupRequestHTTP *req;
+  GInputStream *stream;
+  GError *error = NULL;
+  GString *reply;
+  SoupMessage *message;
+  gchar *req_uri;
+
+  // Test for a known feature.
+  req_uri = g_strdup_printf ("http://localhost:%s/test?feature=query-param-defaultOp",
+                             fixture->port);
+
+  session = soup_session_new ();
+  req = soup_session_request_http (session, SOUP_METHOD_GET,
+                                   req_uri,
+                                   &error);
+  g_assert_no_error (error);
+  g_free (req_uri);
+
+  stream = soup_request_send (SOUP_REQUEST (req), NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (stream);
+
+  reply = flush_stream_to_string (stream);
+  g_assert_cmpint (reply->len, ==, 0);
+
+  message = soup_request_http_get_message (req);
+  g_assert_cmpint (message->status_code, ==, 200);
+
+  g_string_free (reply, TRUE);
+  g_object_unref (req);
+  g_object_unref (session);
+  g_object_unref (message);
+
+  // Test for a unknown feature.
+  req_uri = g_strdup_printf ("http://localhost:%s/test?feature=no-such-feature",
+                             fixture->port);
+
+  session = soup_session_new ();
+  req = soup_session_request_http (session, SOUP_METHOD_GET,
+                                   req_uri,
+                                   &error);
+  g_assert_no_error (error);
+  g_free (req_uri);
+
+  stream = soup_request_send (SOUP_REQUEST (req), NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (stream);
+
+  reply = flush_stream_to_string (stream);
+  g_assert_cmpint (reply->len, ==, 0);
+
+  message = soup_request_http_get_message (req);
+  g_assert_cmpint (message->status_code, ==, 404);
+
+  g_string_free (reply, TRUE);
+  g_object_unref (req);
+  g_object_unref (session);
+  g_object_unref (message);
+
+  // Fail to specify a feature to test for.
+  req_uri = g_strdup_printf ("http://localhost:%s/test",
+                             fixture->port);
+
+  session = soup_session_new ();
+  req = soup_session_request_http (session, SOUP_METHOD_GET,
+                                   req_uri,
+                                   &error);
+  g_assert_no_error (error);
+  g_free (req_uri);
+
+  stream = soup_request_send (SOUP_REQUEST (req), NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (stream);
+
+  reply = flush_stream_to_string (stream);
+  g_assert_cmpint (reply->len, ==, 0);
+
+  message = soup_request_http_get_message (req);
+  g_assert_cmpint (message->status_code, ==, 400);
+
+  g_string_free (reply, TRUE);
+  g_object_unref (req);
+  g_object_unref (session);
+  g_object_unref (message);
+}
+
+static void
 test_get_query_returns_json (DaemonFixture *fixture,
                              gconstpointer user_data)
 {
@@ -164,6 +255,8 @@ main (int argc,
                    test_daemon_starts_successfully);
   ADD_DAEMON_TEST ("/daemon/get-query-returns-json",
                    test_get_query_returns_json);
+  ADD_DAEMON_TEST ("/daemon/feature-testing-works",
+                   test_feature_testing_works);
 
 #undef ADD_DAEMON_TEST
 


### PR DESCRIPTION
Send a GET request to /test with "feature" parameter, which responds:

    200 - Feature supported by this instance of xapian-bridge
    400 - The required "feature" parameter wasn't specified
    404 - Feature not supported by this instance of xapian-bridge

Note: xapian-bridge versions predating the addition of /test return 500
(default response to an unknown URL) so you typically want to handle 500
in the same way as 404.

Currently the only recognised feature is "query-param-defaultOp".