### PR TITLE
Add support for passing filters separately

### DIFF
--- a/src/xb-main.c
+++ b/src/xb-main.c
@@ -35,6 +35,7 @@
 /* JSON array of supported features (for /test). */
 #define XB_FEATURE_JSON_ARRAY "["\
     "\"query-param-defaultOp\","\
+    "\"query-param-filter\","\
     "\"query-param-flags\""\
     "]"
 


### PR DESCRIPTION
Filters can now be specified with "filter" and excluding filters with
"filterOut".  This means that "q" can be used for just the user's query,
which allows various built-in Xapian query parser behaviour to work more
naturally.

It also eliminates unnecessary use the less efficient "pure NOT" when
there are excluding filters.

New feature flag "query-param-filter" indicates that these new
parameters are supported.