### PR TITLE
database manager: query_str is not const

### DIFF
--- a/src/xb-database-manager.c
+++ b/src/xb-database-manager.c
@@ -904,7 +904,8 @@ xb_database_manager_query (XbDatabaseManager *self,
                            GError **error_out)
 {
   XapianQuery *parsed_query = NULL, *filter_query, *filterout_query;
-  const gchar *query_str = NULL, *filter_str, *filterout_str;
+  const gchar *filter_str, *filterout_str;
+  gchar *query_str = NULL;
   XapianEnquire *enquire = NULL;
   GError *error = NULL;
   const gchar *lang;


### PR DESCRIPTION
Missed this in my review. query_str is set with g_strdup(str), and str is
already marked const. query_str needs to be freed.

https://phabricator.endlessm.com/T17002