### PR TITLE
Fix database_is_empty() code to match docs

### DIFF
--- a/src/xb-database-manager.c
+++ b/src/xb-database-manager.c
@@ -672,23 +672,12 @@ xb_database_manager_fetch_results (XbDatabaseManager *self,
 
 /* Checks if the given database is empty (has no documents). Empty databases
  * cause problems with XapianEnquire, so we need to assert that a db isn't empty
- * before making an XapianEnquire for it.
+ * before making a XapianEnquire for it.
  */
 static gboolean
 database_is_empty (XapianDatabase *db)
 {
-  char *uuid;
-
-  /* "If the backend does not support UUIDs or this database has no
-   * subdatabases, the UUID will be empty."
-   * http://xapian.org/docs/apidoc/html/classXapian_1_1Database.html
-   */
-  uuid = xapian_database_get_uuid (db);
-  if (uuid == NULL || uuid[0] == '\0')
-    return TRUE;
-
-  g_free (uuid);
-  return FALSE;
+  return xapian_database_get_doc_count (db) == 0;
 }
 
 static JsonObject *


### PR DESCRIPTION
The documentation comment say "Checks if the given database is empty
(has no documents)" but the code was actually checking if get_uuid()
returned an empty string, which essentially means either there are no
subdatabases or the backend doesn't support UUIDs.  There could be
subdatabases which are empty.

The result of this check is used to short-cut and return an empty
result set, so fixing the code to match the documentation makes
most sense.